### PR TITLE
Refactor Copilot suggestions to provide better completion experience

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,23 +1,15 @@
-from .constants import (
-    PACKAGE_NAME,
-    REQ_CHECK_STATUS,
-    REQ_SIGN_IN_CONFIRM,
-    REQ_SIGN_IN_INITIATE,
-    REQ_SIGN_OUT,
-)
-from .plugin import CopilotPlugin
-from .types import (
-    CopilotPayloadSignInConfirm,
-    CopilotPayloadSignInInitiate,
-    CopilotPayloadSignOut,
-)
-from .ui import Completion
 from abc import ABCMeta
+
+import sublime
+import sublime_plugin
 from LSP.plugin import Request
 from LSP.plugin.core.registry import LspTextCommand
 from LSP.plugin.core.typing import Tuple, Union
-import sublime
-import sublime_plugin
+
+from .constants import PACKAGE_NAME, REQ_CHECK_STATUS, REQ_SIGN_IN_CONFIRM, REQ_SIGN_IN_INITIATE, REQ_SIGN_OUT
+from .plugin import CopilotPlugin
+from .types import CopilotPayloadSignInConfirm, CopilotPayloadSignInInitiate, CopilotPayloadSignOut
+from .ui import Completion
 
 
 class CopilotInsertAsIsCommand(sublime_plugin.TextCommand):

--- a/listeners.py
+++ b/listeners.py
@@ -1,14 +1,15 @@
+import functools
+
 import sublime
+import sublime_plugin
+from LSP.plugin.core.types import FEATURES_TIMEOUT, debounced
+
 from .plugin import CopilotPlugin
 from .ui import Completion
-from LSP.plugin.core.types import debounced
-from LSP.plugin.core.types import FEATURES_TIMEOUT
-import functools
-import sublime_plugin
 
 
 class EventListener(sublime_plugin.ViewEventListener):
-    COPILOT_SUGGESTION_VISIBLE = 'copilot_suggestion_visible'
+    COPILOT_SUGGESTION_VISIBLE = "copilot_suggestion_visible"
 
     def on_modified_async(self) -> None:
         plugin = CopilotPlugin.plugin_from_view(self.view)

--- a/plugin.py
+++ b/plugin.py
@@ -1,3 +1,12 @@
+import functools
+import os
+import weakref
+
+import sublime
+from LSP.plugin import Request, Session, filename_to_uri
+from LSP.plugin.core.typing import Optional, Tuple
+from lsp_utils import ApiWrapperInterface, NpmClientHandler, notification_handler
+
 from .constants import (
     COPILOT_WAITING_COMPLETION_KEY,
     NTFY_LOG_MESSAGE,
@@ -16,17 +25,6 @@ from .types import (
 )
 from .ui import Completion
 from .utils import get_project_relative_path
-from LSP.plugin import filename_to_uri
-from LSP.plugin import Request
-from LSP.plugin import Session
-from LSP.plugin.core.typing import Optional, Tuple
-from lsp_utils import ApiWrapperInterface
-from lsp_utils import notification_handler
-from lsp_utils import NpmClientHandler
-import functools
-import os
-import sublime
-import weakref
 
 
 def plugin_loaded():
@@ -180,6 +178,4 @@ class CopilotPlugin(NpmClientHandler):
         if not completions:
             return
 
-        sublime.set_timeout_async(
-            lambda: Completion(view).show(region, completions)
-        )
+        sublime.set_timeout_async(lambda: Completion(view).show(region, completions))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ ignore_missing_imports = true
 
 [tool.isort]
 profile = 'black'
+line_length = 120
 
 [tool.black]
 line-length = 120

--- a/ui.py
+++ b/ui.py
@@ -1,40 +1,40 @@
 import textwrap
-from .constants import COPILOT_VIEW_SETTINGS_PREFIX
-from .types import (
-    CopilotPayloadCompletion,
-)
-from LSP.plugin.core.typing import List, Tuple
-import sublime
+
 import mdpopups
+import sublime
+from LSP.plugin.core.typing import List, Tuple
+
+from .constants import COPILOT_VIEW_SETTINGS_PREFIX
+from .types import CopilotPayloadCompletion
 
 
 class Completion:
     def __init__(self, view: sublime.View):
         self.view = view
 
-    def _settings(self, key, default_or_new_value=None, do: str = 'get'):
-        settings_key = '{}.{}'.format(COPILOT_VIEW_SETTINGS_PREFIX, key)
+    def _settings(self, key, default_or_new_value=None, do: str = "get"):
+        settings_key = "{}.{}".format(COPILOT_VIEW_SETTINGS_PREFIX, key)
 
-        if do == 'set':
+        if do == "set":
             return self.view.settings().set(settings_key, default_or_new_value)
-        elif do == 'erase':
+        elif do == "erase":
             return self.view.settings().erase(settings_key)
         else:
             return self.view.settings().get(settings_key, default_or_new_value)
 
     @property
     def region(self):
-        return self._settings('region')
+        return self._settings("region")
 
     @property
     def display_text(self):
-        return self._settings('display_text')
+        return self._settings("display_text")
 
     def is_visible(self) -> bool:
         return bool(self.region) and bool(self.display_text)
 
     def get_display_text(self, region: Tuple[int, int], raw_display_text: str):
-        if '\n' in raw_display_text:
+        if "\n" in raw_display_text:
             return raw_display_text
 
         if (self.view.classify(region[1]) & sublime.CLASS_LINE_END) != 0:
@@ -49,24 +49,24 @@ class Completion:
     def hide(self):
         PopupCompletion.hide(self.view)
 
-        self._settings('region', do='erase')
-        self._settings('display_text', do='erase')
+        self._settings("region", do="erase")
+        self._settings("display_text", do="erase")
 
     def show(self, region: Tuple[int, int], completions: List[CopilotPayloadCompletion], cycle: int = 0):
         cycle %= len(completions)
-        display_text = self.get_display_text(region, completions[cycle]['displayText'])
+        display_text = self.get_display_text(region, completions[cycle]["displayText"])
 
         if not display_text:
             return
 
-        self._settings('region', region, do='set')
-        self._settings('display_text', display_text, do='set')
+        self._settings("region", region, do="set")
+        self._settings("display_text", display_text, do="set")
 
         PopupCompletion(self.view, region, display_text).show()
 
 
 class PopupCompletion:
-    CSS_CLASS_NAME = 'copilot-suggestion-popup'
+    CSS_CLASS_NAME = "copilot-suggestion-popup"
     CSS = """
     .{class_name} {{
         margin-left: 10px;
@@ -77,7 +77,9 @@ class PopupCompletion:
     .{class_name} a {{
         display: block;
     }}
-    """.format(class_name=CSS_CLASS_NAME)
+    """.format(
+        class_name=CSS_CLASS_NAME
+    )
     COMPLETION_TEMPLATE = '<a href="subl:copilot_accept_suggestion">Accept ⇥</a>\n```{lang}\n{code}\n```'
 
     @staticmethod
@@ -107,7 +109,7 @@ class PopupCompletion:
     @property
     def content(self):
         return self.COMPLETION_TEMPLATE.format(
-            lang=self.syntax.scope.rpartition('.')[2],
+            lang=self.syntax.scope.rpartition(".")[2],
             code=self._prepare_display_text(),
         )
 

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import os
+
 import sublime
 
 


### PR DESCRIPTION
The original idea of this PR was to slightly improve Copilot's suggestion and remove the part of the suggestion that is already present in the line. But when I started working on it I realised that it would require some refactoring as the package wasn't designed to handle suggestions in that way. So I ended up with this PR. 
<img width="295" alt="Знімок екрана 2022-07-13 о 13 47 10" src="https://user-images.githubusercontent.com/471335/178738069-1a30048e-a4c0-44f9-8b4c-7b2c8ecbcf2a.png">

Here is a short summary of what this PR does:

- parses suggestions and removes the part of the text that it is already visible(this is only the case for completion inside line). This provides a much better user experience because in most cases you can use the suggestion as it is as previously you had to correct all accepted suggestions from the middle of the line 
- keeps the current suggestion in the view settings that allows having a custom context and binding `Tab`/`Esc` to accept/dismiss the current suggestion
- introduces the `ui.Completion` class with all completion-related logic (including `PopupCompletion` with popup logic)
- minor styling improvements (some margins, etc)
- reorganises the structure a bit(mostly to support new changes)
- default key bindings(`Tab` to accept, `Esc` to dismiss). We could comment them by default but keep them in the file so users can copy and paste them if needed

There are still some edge cases. For example, sometimes Copilot suggests a completely different end of the line. I will keep an eye on such cases and create a separate PR as it might require some time to collect all of them and compare how VSCode/neovim handles them.