### PR TITLE
feat: hide suggestion on focus lost

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -14,6 +14,9 @@ from .ui import Completion
 class CopilotTextCommand(LspTextCommand, metaclass=ABCMeta):
     session_name = PACKAGE_NAME
 
+    def want_event(self) -> bool:
+        return False
+
 
 class CopilotAcceptSuggestionCommand(CopilotTextCommand):
     def run(self, edit: sublime.Edit) -> None:

--- a/commands.py
+++ b/commands.py
@@ -34,12 +34,7 @@ class CopilotAcceptSuggestionCommand(CopilotTextCommand):
 
 class CopilotDismissSuggestionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
-        completion = Completion(self.view)
-
-        if not completion.is_visible():
-            return
-
-        completion.hide()
+        Completion(self.view).hide()
 
 
 class CopilotCheckStatusCommand(CopilotTextCommand):

--- a/listeners.py
+++ b/listeners.py
@@ -35,4 +35,8 @@ class EventListener(sublime_plugin.ViewEventListener):
             return completion.is_visible() == operand
         if operator == sublime.OP_NOT_EQUAL:
             return completion.is_visible() != operand
+
         return None
+
+    def on_deactivated_async(self) -> None:
+        Completion(self.view).hide()

--- a/ui.py
+++ b/ui.py
@@ -77,6 +77,7 @@ class PopupCompletion:
 
     .{class_name} a {{
         display: block;
+        text-decoration: none;
     }}
     """.format(
         class_name=CSS_CLASS_NAME

--- a/ui.py
+++ b/ui.py
@@ -121,7 +121,7 @@ class PopupCompletion:
     COMPLETION_TEMPLATE = (
         '<div class="header">'
         '<a class="accept" href="subl:copilot_accept_suggestion"><i>✓</i> Accept</a>&nbsp;'
-        '<a class="dismiss" href="subl:copilot_dimiss_suggestion"><i>×</i> Dismiss</a>'
+        '<a class="dismiss" href="subl:copilot_dismiss_suggestion"><i>×</i> Dismiss</a>'
         "</div>"
         "\n"
         "```{lang}\n{code}\n```"

--- a/ui.py
+++ b/ui.py
@@ -69,20 +69,63 @@ class Completion:
 class PopupCompletion:
     CSS_CLASS_NAME = "copilot-suggestion-popup"
     CSS = """
+    html {{
+        --copilot-accept-foreground: var(--foreground);
+        --copilot-accept-background: var(--background);
+        --copilot-accept-border: var(--greenish);
+        --copilot-dismiss-foreground: var(--foreground);
+        --copilot-dismiss-background: var(--background);
+        --copilot-dismiss-border: var(--yellowish);
+    }}
+
     .{class_name} {{
-        margin-left: 10px;
-        margin-right: 10px;
-        margin-top: 10px;
+        margin: 1rem 0.5rem 0 0.5rem;
+    }}
+
+    .{class_name} .header {{
+        display: block;
+        margin-bottom: 1rem;
     }}
 
     .{class_name} a {{
-        display: block;
+        border-radius: 3px;
+        border-style: solid;
+        border-width: 1px;
+        display: inline;
+        padding: 5px;
         text-decoration: none;
+    }}
+
+    .{class_name} a.accept {{
+        background: var(--copilot-accept-background);
+        border-color: var(--copilot-accept-border);
+        color: var(--copilot-accept-foreground);
+    }}
+
+    .{class_name} a.accept i {{
+        color: var(--copilot-accept-border);
+    }}
+
+    .{class_name} a.dismiss {{
+        background: var(--copilot-dismiss-background);
+        border-color: var(--copilot-dismiss-border);
+        color: var(--copilot-dismiss-foreground);
+    }}
+
+    .{class_name} a.dismiss i {{
+        color: var(--copilot-dismiss-border);
     }}
     """.format(
         class_name=CSS_CLASS_NAME
     )
-    COMPLETION_TEMPLATE = '<a href="subl:copilot_accept_suggestion">Accept ⇥</a>\n```{lang}\n{code}\n```'
+    COMPLETION_TEMPLATE = (
+        '<div class="header">'
+        '<a class="accept" href="subl:copilot_accept_suggestion"><i>✓</i> Accept</a>&nbsp;'
+        '<a class="dismiss" href="subl:copilot_dimiss_suggestion"><i>×</i> Dismiss</a>'
+        "</div>"
+        "\n"
+        "```{lang}\n{code}\n```"
+    )
 
     def __init__(self, view: sublime.View, region: Tuple[int, int], display_text: str) -> None:
         self.view = view


### PR DESCRIPTION
I think it would be nice to hide the suggestion when switching between views.

This PR also removes underscore for the `Accept ⇥` link. I think it is a bit cleaner this way
Accept 
<img width="290" alt="Знімок екрана 2022-07-14 о 12 29 05" src="https://user-images.githubusercontent.com/471335/178972710-6db7c9f1-d5df-4165-b37d-ab0d389d7704.png">