### PR TITLE
feat: previous/next completions

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -20,5 +20,27 @@
                 "key": "setting.copilot.completion.is_visible"
             }
         ]
-    }
+    },
+    // {
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "command": "copilot_previous_suggestion",
+    //     "context": [
+    //         {
+    //             "key": "setting.copilot.completion.is_visible",
+    //         }
+    //     ]
+    // },
+    // {
+    //     "keys": [
+    //         "UNBOUND"
+    //     ],
+    //     "command": "copilot_next_suggestion",
+    //     "context": [
+    //         {
+    //             "key": "setting.copilot.completion.is_visible"
+    //         }
+    //     ]
+    // },
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -21,6 +21,28 @@
             }
         ]
     },
+    {
+        "keys": [
+            "alt+["
+        ],
+        "command": "copilot_previous_suggestion",
+        "context": [
+            {
+                "key": "setting.copilot.completion.is_visible",
+            }
+        ]
+    },
+    {
+        "keys": [
+            "alt+]"
+        ],
+        "command": "copilot_next_suggestion",
+        "context": [
+            {
+                "key": "setting.copilot.completion.is_visible"
+            }
+        ]
+    },
     // {
     //     "keys": [
     //         "UNBOUND"
@@ -29,28 +51,6 @@
     //     "context": [
     //         {
     //             "key": "setting.lsp_active",
-    //         }
-    //     ]
-    // },
-    // {
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "command": "copilot_previous_suggestion",
-    //     "context": [
-    //         {
-    //             "key": "setting.copilot.completion.is_visible",
-    //         }
-    //     ]
-    // },
-    // {
-    //     "keys": [
-    //         "UNBOUND"
-    //     ],
-    //     "command": "copilot_next_suggestion",
-    //     "context": [
-    //         {
-    //             "key": "setting.copilot.completion.is_visible"
     //         }
     //     ]
     // },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,7 +3,7 @@
         "keys": [
             "tab"
         ],
-        "command": "copilot_accept_suggestion",
+        "command": "copilot_accept_completion",
         "context": [
             {
                 "key": "setting.copilot.completion.is_visible"
@@ -14,7 +14,7 @@
         "keys": [
             "escape"
         ],
-        "command": "copilot_reject_suggestion",
+        "command": "copilot_reject_completion",
         "context": [
             {
                 "key": "setting.copilot.completion.is_visible"
@@ -25,7 +25,7 @@
         "keys": [
             "alt+["
         ],
-        "command": "copilot_previous_suggestion",
+        "command": "copilot_previous_completion",
         "context": [
             {
                 "key": "setting.copilot.completion.is_visible",
@@ -36,7 +36,7 @@
         "keys": [
             "alt+]"
         ],
-        "command": "copilot_next_suggestion",
+        "command": "copilot_next_completion",
         "context": [
             {
                 "key": "setting.copilot.completion.is_visible"

--- a/commands.py
+++ b/commands.py
@@ -93,7 +93,7 @@ class CopilotAskCompletionsCommand(CopilotTextCommand):
         )
 
 
-class CopilotAcceptSuggestionCommand(CopilotTextCommand):
+class CopilotAcceptCompletionCommand(CopilotTextCommand):
     @_provide_session()
     def run(self, session: Session, edit: sublime.Edit) -> None:
         completion_manager = ViewCompletionManager(self.view)
@@ -122,7 +122,7 @@ class CopilotAcceptSuggestionCommand(CopilotTextCommand):
             self._record_telemetry(session, REQ_NOTIFY_REJECTED, {"uuids": other_uuids})
 
 
-class CopilotRejectSuggestionCommand(CopilotTextCommand):
+class CopilotRejectCompletionCommand(CopilotTextCommand):
     @_provide_session()
     def run(self, session: Session, _: sublime.Edit) -> None:
         completion_manager = ViewCompletionManager(self.view)
@@ -136,12 +136,12 @@ class CopilotRejectSuggestionCommand(CopilotTextCommand):
         )
 
 
-class CopilotPreviousSuggestionCommand(CopilotTextCommand):
+class CopilotPreviousCompletionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
         ViewCompletionManager(self.view).show_previous_completion()
 
 
-class CopilotNextSuggestionCommand(CopilotTextCommand):
+class CopilotNextCompletionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
         ViewCompletionManager(self.view).show_next_completion()
 

--- a/commands.py
+++ b/commands.py
@@ -138,16 +138,12 @@ class CopilotRejectSuggestionCommand(CopilotTextCommand):
 
 class CopilotPreviousSuggestionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
-        completion_manager = ViewCompletionManager(self.view)
-        completion_manager.choose_previous_completion()
-        completion_manager.show()
+        ViewCompletionManager(self.view).show_previous_completion()
 
 
 class CopilotNextSuggestionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
-        completion_manager = ViewCompletionManager(self.view)
-        completion_manager.choose_next_completion()
-        completion_manager.show()
+        ViewCompletionManager(self.view).show_next_completion()
 
 
 class CopilotCheckStatusCommand(CopilotTextCommand):

--- a/commands.py
+++ b/commands.py
@@ -123,14 +123,14 @@ class CopilotRejectSuggestionCommand(CopilotTextCommand):
 class CopilotPreviousSuggestionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
         completion_manager = ViewCompletionManager(self.view)
-        completion_manager.cycle_previous()
+        completion_manager.choose_previous_completion()
         completion_manager.show()
 
 
 class CopilotNextSuggestionCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
         completion_manager = ViewCompletionManager(self.view)
-        completion_manager.cycle_next()
+        completion_manager.choose_next_completion()
         completion_manager.show()
 
 

--- a/listeners.py
+++ b/listeners.py
@@ -4,7 +4,7 @@ import sublime_plugin
 from LSP.plugin.core.types import FEATURES_TIMEOUT, debounced
 
 from .plugin import CopilotPlugin
-from .ui import Completion
+from .ui import ViewCompletionManager
 from .utils import get_copilot_view_setting
 
 
@@ -22,4 +22,4 @@ class EventListener(sublime_plugin.ViewEventListener):
         )
 
     def on_deactivated_async(self) -> None:
-        Completion(self.view).hide()
+        ViewCompletionManager(self.view).hide()

--- a/listeners.py
+++ b/listeners.py
@@ -2,7 +2,7 @@ import sublime_plugin
 
 from .plugin import CopilotPlugin
 from .ui import ViewCompletionManager
-from .utils import get_copilot_view_setting, get_setting
+from .utils import get_setting
 
 
 class EventListener(sublime_plugin.ViewEventListener):

--- a/plugin.py
+++ b/plugin.py
@@ -177,6 +177,4 @@ class CopilotPlugin(NpmClientHandler):
 
         preprocess_completions(view, completions)
 
-        set_copilot_view_setting(view, "completions", completions)
-        set_copilot_view_setting(view, "completion_index", 0)
-        ViewCompletionManager(view).show()
+        ViewCompletionManager(view).show(completions, 0)

--- a/plugin.py
+++ b/plugin.py
@@ -178,5 +178,5 @@ class CopilotPlugin(NpmClientHandler):
         preprocess_completions(view, completions)
 
         set_copilot_view_setting(view, "completions", completions)
-        set_copilot_view_setting(view, "cycle", 0)
+        set_copilot_view_setting(view, "completion_index", 0)
         ViewCompletionManager(view).show()

--- a/plugin.py
+++ b/plugin.py
@@ -22,8 +22,8 @@ from .types import (
     CopilotPayloadSignInConfirm,
     CopilotPayloadStatusNotification,
 )
-from .ui import Completion
-from .utils import get_project_relative_path, set_copilot_view_setting
+from .ui import ViewCompletionManager
+from .utils import get_project_relative_path, preprocess_completions, set_copilot_view_setting
 
 
 def plugin_loaded() -> None:
@@ -127,7 +127,7 @@ class CopilotPlugin(NpmClientHandler):
         pass
 
     def request_get_completions(self, view: sublime.View) -> None:
-        Completion(view).hide()
+        ViewCompletionManager(view).hide()
 
         session = self.weaksession()
         syntax = view.syntax()
@@ -143,7 +143,7 @@ class CopilotPlugin(NpmClientHandler):
                 "source": view.substr(sublime.Region(0, view.size())),
                 "tabSize": view.settings().get("tab_size", 4),
                 "indentSize": 1,  # there is no such concept in ST
-                "insertSpaces": False,  # always use TAB and let ST auto converts it accordingly
+                "insertSpaces": view.settings().get("translate_tabs_to_spaces", False),
                 "path": file_path,
                 "uri": file_path and filename_to_uri(file_path),
                 "relativePath": get_project_relative_path(file_path),
@@ -175,4 +175,8 @@ class CopilotPlugin(NpmClientHandler):
         if not completions:
             return
 
-        Completion(view).show(region, completions)
+        preprocess_completions(view, completions)
+
+        set_copilot_view_setting(view, "completions", completions)
+        set_copilot_view_setting(view, "cycle", 0)
+        ViewCompletionManager(view).show()

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -31,7 +31,7 @@
                     },
                     "telemetry": {
                       "default": false,
-                      "markdownDescription": "Enables Copilot telemetry requests for `Accept` and `Reject` Suggestions.",
+                      "markdownDescription": "Enables Copilot telemetry requests for `Accept` and `Reject` completions.",
                       "type": "boolean"
                     }
                   }

--- a/types.py
+++ b/types.py
@@ -28,7 +28,7 @@ CopilotPayloadCompletion = TypedDict(
         "uuid": str,
         "range": CopilotPayloadCompletionRange,
         "displayText": str,
-        # # injected for convenience
+        # injected for convenience
         "positionSt": int,
     },
     total=True,

--- a/types.py
+++ b/types.py
@@ -28,6 +28,8 @@ CopilotPayloadCompletion = TypedDict(
         "uuid": str,
         "range": CopilotPayloadCompletionRange,
         "displayText": str,
+        # # injected for convenience
+        "positionSt": int,
     },
     total=True,
 )

--- a/ui.py
+++ b/ui.py
@@ -150,12 +150,16 @@ class _PopupCompletion:
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
         border-right-width: 0;
+        padding-left: 8px;
+        padding-right: 8px;
     }}
 
     .{class_name} a.next {{
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         border-left-width: 0;
+        padding-left: 8px;
+        padding-right: 8px;
     }}
     """.format(
         class_name=CSS_CLASS_NAME

--- a/ui.py
+++ b/ui.py
@@ -36,8 +36,10 @@ class ViewCompletionManager:
         self._set_cycle(self.cycle + 1)
 
     def hide(self) -> None:
-        set_copilot_view_setting(self.view, "is_visible", False)
-        _PopupCompletion.hide(self.view)
+        # to prevent from hiding other plugin's popup
+        if self.is_visible:
+            set_copilot_view_setting(self.view, "is_visible", False)
+            _PopupCompletion.hide(self.view)
 
     def show(self) -> None:
         completion = self.current_completion

--- a/ui.py
+++ b/ui.py
@@ -166,8 +166,8 @@ class _PopupCompletion:
             '<a class="reject" href="subl:copilot_reject_suggestion"><i>×</i> Reject</a>',
         ]
         if completions_cnt > 1:
-            header_items.append('<a class="previous" href="subl:copilot_previous_suggestion">▲ Previous</a>')
-            header_items.append('<a class="next" href="subl:copilot_next_suggestion">▼ Next</a>')
+            header_items.append('<a class="previous" href="subl:copilot_previous_suggestion">◀ Previous</a>')
+            header_items.append('<a class="next" href="subl:copilot_next_suggestion">▶ Next</a>')
             header_items.append(
                 "({completion_index_1} of {completions_cnt})".format(
                     completion_index_1=self.completion_manager.completion_index + 1,  # 1-base index

--- a/ui.py
+++ b/ui.py
@@ -67,7 +67,7 @@ class ViewCompletionManager:
 
         _PopupCompletion(self.view).show()
 
-    def _set_completion_index(self, value: int, do_clamp: bool = False) -> None:
+    def _set_completion_index(self, value: int, do_clamp: bool = True) -> None:
         """
         Set `completion_index`.
 

--- a/ui.py
+++ b/ui.py
@@ -34,19 +34,21 @@ class ViewCompletionManager:
         completions = self.completions
         return completions[self.completion_index] if completions else None
 
-    def choose_previous_completion(self) -> None:
+    def show_previous_completion(self) -> None:
         """Set `completion_index` to be for the previous completion."""
         self._set_completion_index(
             self.completion_index - 1,
             do_clamp=not self.view.settings().get("auto_complete_cycle", False),
         )
+        self.show()
 
-    def choose_next_completion(self) -> None:
+    def show_next_completion(self) -> None:
         """Set `completion_index` to be for the next completion."""
         self._set_completion_index(
             self.completion_index + 1,
             do_clamp=not self.view.settings().get("auto_complete_cycle", False),
         )
+        self.show()
 
     def hide(self) -> None:
         """Hide Copilot's completion popup."""

--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,5 @@
 import textwrap
+from functools import partial
 
 import mdpopups
 import sublime
@@ -51,7 +52,6 @@ class ViewCompletionManager:
         """Hide Copilot's completion popup."""
         # to prevent from hiding other plugin's popup
         if self.is_visible:
-            set_copilot_view_setting(self.view, "is_visible", False)
             _PopupCompletion.hide(self.view)
 
     def show(self) -> None:
@@ -65,7 +65,6 @@ class ViewCompletionManager:
         if completion["text"] == self.view.substr(current_line):
             return
 
-        set_copilot_view_setting(self.view, "is_visible", True)
         _PopupCompletion(self.view).show()
 
     def _set_completion_index(self, value: int, do_clamp: bool = False) -> None:
@@ -197,9 +196,9 @@ class _PopupCompletion:
     def show(self) -> None:
         self.hide(self.view)
 
+        set_copilot_view_setting(self.view, "is_visible", True)
         mdpopups.show_popup(
             view=self.view,
-            # multiple lines are not supported
             content=self.popup_content,
             md=True,
             css=self.CSS,
@@ -207,6 +206,7 @@ class _PopupCompletion:
             flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
             max_width=640,
             wrapper_class=self.CSS_CLASS_NAME,
+            on_hide=partial(set_copilot_view_setting, self.view, "is_visible", False),
         )
 
     @staticmethod

--- a/ui.py
+++ b/ui.py
@@ -83,7 +83,7 @@ class ViewCompletionManager:
         """
         Revise `completion_index` to a valid value, or `0` if `self.completions` is empty.
 
-        :param      do_clamp:  Do clamped if `completion_index` is out-of-bound? Otherwise, treat it as cyclic.
+        :param      do_clamp:  Clamp `completion_index` if it's out-of-bounds. Otherwise, treat it as cyclic.
         """
         completions_cnt = len(self.completions)
         if completions_cnt:

--- a/ui.py
+++ b/ui.py
@@ -97,7 +97,7 @@ class ViewCompletionManager:
 
 
 class _PopupCompletion:
-    CSS_CLASS_NAME = "copilot-suggestion-popup"
+    CSS_CLASS_NAME = "copilot-completion-popup"
     CSS = """
     html {{
         --copilot-accept-foreground: var(--foreground);
@@ -186,13 +186,13 @@ class _PopupCompletion:
     def popup_header_items(self) -> List[str]:
         completions_cnt = len(self.completion_manager.completions)
         header_items = [
-            '<a class="accept" href="subl:copilot_accept_suggestion"><i>✓</i> Accept</a>',
-            '<a class="reject" href="subl:copilot_reject_suggestion"><i>×</i> Reject</a>',
+            '<a class="accept" href="subl:copilot_accept_completion"><i>✓</i> Accept</a>',
+            '<a class="reject" href="subl:copilot_reject_completion"><i>×</i> Reject</a>',
         ]
         if completions_cnt > 1:
             header_items.append(
-                '<a class="prev" href="subl:copilot_previous_suggestion">◀</a>'
-                + '<a class="next" href="subl:copilot_next_suggestion">▶</a>'
+                '<a class="prev" href="subl:copilot_previous_completion">◀</a>'
+                + '<a class="next" href="subl:copilot_next_completion">▶</a>'
             )
             header_items.append(
                 "({completion_index_1} of {completions_cnt})".format(
@@ -242,7 +242,7 @@ class _PopupCompletion:
 
     @staticmethod
     def _prepare_popup_code_display_text(display_text: str) -> str:
-        # The returned suggestion is in the form of
+        # The returned completion is in the form of
         #   - the first won't be indented
         #   - the rest of lines will be indented basing on the indentation level of the current line
         # The rest of lines don't visually look good if the current line is deeply indented.

--- a/ui.py
+++ b/ui.py
@@ -25,7 +25,7 @@ class ViewCompletionManager:
 
     @property
     def completion_index(self) -> int:
-        """The current index of the chosen completion."""
+        """The index of the current chosen completion."""
         return get_copilot_view_setting(self.view, "completion_index", 0)
 
     @property
@@ -34,7 +34,7 @@ class ViewCompletionManager:
         return self.completions[self.completion_index] if self.completions else None
 
     def show_previous_completion(self) -> None:
-        """Set `completion_index` to be for the previous completion."""
+        """Show the previous completion."""
         self.show(
             None,
             self.completion_index - 1,
@@ -42,7 +42,7 @@ class ViewCompletionManager:
         )
 
     def show_next_completion(self) -> None:
-        """Set `completion_index` to be for the next completion."""
+        """Show the next completion."""
         self.show(
             None,
             self.completion_index + 1,
@@ -51,7 +51,7 @@ class ViewCompletionManager:
 
     def hide(self) -> None:
         """Hide Copilot's completion popup."""
-        # to prevent from hiding other plugin's popup
+        # prevent from hiding other plugin's popup
         if self.is_visible:
             _PopupCompletion.hide(self.view)
 

--- a/ui.py
+++ b/ui.py
@@ -167,7 +167,7 @@ class _PopupCompletion:
         ]
         if completions_cnt > 1:
             header_items.append('<a class="previous" href="subl:copilot_previous_suggestion">◀ Previous</a>')
-            header_items.append('<a class="next" href="subl:copilot_next_suggestion">▶ Next</a>')
+            header_items.append('<a class="next" href="subl:copilot_next_suggestion">Next ▶</a>')
             header_items.append(
                 "({completion_index_1} of {completions_cnt})".format(
                     completion_index_1=self.completion_manager.completion_index + 1,  # 1-base index

--- a/ui.py
+++ b/ui.py
@@ -216,7 +216,7 @@ class _PopupCompletion:
         # Hence we modify the rest of lines into always indented by one level if it's originally indented.
         first_line, sep, rest = display_text.partition("\n")
 
-        if rest.startswith("\t"):
+        if rest.startswith((" ", "\t")):
             return first_line + sep + textwrap.indent(textwrap.dedent(rest), "\t")
 
         return display_text

--- a/ui.py
+++ b/ui.py
@@ -225,8 +225,6 @@ class _PopupCompletion:
         return display_text[:index] if following_text and index != -1 else display_text
 
     def show(self) -> None:
-        self.hide(self.view)
-
         set_copilot_view_setting(self.view, "is_visible", True)
         mdpopups.show_popup(
             view=self.view,

--- a/ui.py
+++ b/ui.py
@@ -36,16 +36,14 @@ class ViewCompletionManager:
     def show_previous_completion(self) -> None:
         """Show the previous completion."""
         self.show(
-            None,
-            self.completion_index - 1,
+            completion_index=self.completion_index - 1,
             do_clamp=not self.view.settings().get("auto_complete_cycle", False),
         )
 
     def show_next_completion(self) -> None:
         """Show the next completion."""
         self.show(
-            None,
-            self.completion_index + 1,
+            completion_index=self.completion_index + 1,
             do_clamp=not self.view.settings().get("auto_complete_cycle", False),
         )
 

--- a/ui.py
+++ b/ui.py
@@ -145,6 +145,18 @@ class _PopupCompletion:
     .{class_name} a.reject i {{
         color: var(--copilot-reject-border);
     }}
+
+    .{class_name} a.prev {{
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        border-right-width: 0;
+    }}
+
+    .{class_name} a.next {{
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        border-left-width: 0;
+    }}
     """.format(
         class_name=CSS_CLASS_NAME
     )
@@ -178,11 +190,13 @@ class _PopupCompletion:
             '<a class="reject" href="subl:copilot_reject_suggestion"><i>×</i> Reject</a>',
         ]
         if completions_cnt > 1:
-            header_items.append('<a class="previous" href="subl:copilot_previous_suggestion">◀ Previous</a>')
-            header_items.append('<a class="next" href="subl:copilot_next_suggestion">Next ▶</a>')
+            header_items.append(
+                '<a class="prev" href="subl:copilot_previous_suggestion">◀</a>'
+                + '<a class="next" href="subl:copilot_next_suggestion">▶</a>'
+            )
             header_items.append(
                 "({completion_index_1} of {completions_cnt})".format(
-                    completion_index_1=self.completion_manager.completion_index + 1,  # 1-base index
+                    completion_index_1=self.completion_manager.completion_index + 1,  # 1-based index
                     completions_cnt=completions_cnt,
                 )
             )

--- a/ui.py
+++ b/ui.py
@@ -66,7 +66,7 @@ class ViewCompletionManager:
         # update completion index
         if completion_index is not None:
             set_copilot_view_setting(self.view, "completion_index", completion_index)
-        self._tidy_completion_index(do_clamp=do_clamp)
+        self._tidy_completion_index(do_clamp)
 
         completion = self.current_completion
         if not completion:

--- a/ui.py
+++ b/ui.py
@@ -31,8 +31,7 @@ class ViewCompletionManager:
     @property
     def current_completion(self) -> Optional[CopilotPayloadCompletion]:
         """The current chosen `completion`."""
-        completions = self.completions
-        return completions[self.completion_index] if completions else None
+        return self.completions[self.completion_index] if self.completions else None
 
     def show_previous_completion(self) -> None:
         """Set `completion_index` to be for the previous completion."""

--- a/ui.py
+++ b/ui.py
@@ -74,7 +74,7 @@ class ViewCompletionManager:
 
         :param      value:     The wanted new completion index.
         :param      do_clamp:  Should the `value` be clamped if it's
-                               out-of-bound? Otherwise, treat it as circular.
+                               out-of-bound? Otherwise, treat it as cyclic.
         """
         completions_cnt = len(self.completions)
         if completions_cnt:

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.typing import Any, List, Optional, Union
 
 from .constants import COPILOT_VIEW_SETTINGS_PREFIX
+from .types import CopilotPayloadCompletion
 
 
 def get_copilot_view_setting(view: sublime.View, key: str, default: Any = None) -> Any:
@@ -35,6 +36,14 @@ def get_setting(session: Session, key: str, default: Optional[Union[str, bool, L
     if value is None:
         return default
     return value
+
+
+def preprocess_completions(view: sublime.View, completions: List[CopilotPayloadCompletion]) -> None:
+    for completion in completions:
+        completion["positionSt"] = view.text_point(
+            completion["position"]["line"],
+            completion["position"]["character"],
+        )
 
 
 def reformat(text: str) -> str:

--- a/utils.py
+++ b/utils.py
@@ -3,10 +3,21 @@ import textwrap
 
 import sublime
 from LSP.plugin.core.sessions import Session
-from LSP.plugin.core.typing import Any, List, Optional, Union
+from LSP.plugin.core.typing import Any, List, Optional, TypeVar, Union
 
 from .constants import COPILOT_VIEW_SETTINGS_PREFIX
 from .types import CopilotPayloadCompletion
+
+T_Number = TypeVar("T_Number", bound=Union[int, float])
+
+
+def clamp(val: T_Number, min_val: Optional[T_Number] = None, max_val: Optional[T_Number] = None) -> T_Number:
+    """Returns the bounded value of `val` in the range of `[min_val, max_val]`."""
+    if min_val is not None and val < min_val:  # type: ignore
+        return min_val
+    if max_val is not None and val > max_val:  # type: ignore
+        return max_val
+    return val
 
 
 def get_copilot_view_setting(view: sublime.View, key: str, default: Any = None) -> Any:


### PR DESCRIPTION
https://user-images.githubusercontent.com/6594915/179384384-a0e35df5-7184-4369-972b-2195edd755ee.mp4

Use `alt+[` and `alt+]` to do completion cycling.

---

Now we store following things in view settings:

- is_visible
- is_waiting
- completions (full completions payload from copilot)
- completion_index (0-based index of the current chosen completion)

---

Resolves #6