### PR TITLE
feat: hook to auto_complete command

### DIFF
--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -12,6 +12,7 @@
 	"initializationOptions": {},
 	"settings": {
 		"auto_ask_completions": true,
+		"hook_to_auto_complete_command": false,
 		"debug": false,
 		"telemetry": false
 	},

--- a/commands.py
+++ b/commands.py
@@ -1,4 +1,3 @@
-import functools
 from abc import ABCMeta
 from functools import partial, wraps
 
@@ -6,7 +5,6 @@ import sublime
 from LSP.plugin import Request, Session
 from LSP.plugin.core import registry
 from LSP.plugin.core.registry import LspTextCommand, sublime_plugin
-from LSP.plugin.core.types import FEATURES_TIMEOUT, debounced
 from LSP.plugin.core.typing import Any, Callable, Optional, Union, cast
 
 from .constants import (
@@ -157,12 +155,7 @@ class CopilotAskCompletionsCommand(CopilotTextCommand):
         if not plugin:
             return
 
-        debounced(
-            functools.partial(plugin.request_get_completions, self.view),
-            FEATURES_TIMEOUT,
-            lambda: not ViewCompletionManager(self.view).is_waiting,
-            async_thread=True,
-        )
+        plugin.request_get_completions(self.view)
 
 
 class CopilotAcceptPanelCompletionShimCommand(CopilotWindowCommand):

--- a/listeners.py
+++ b/listeners.py
@@ -55,7 +55,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             return test(CopilotPlugin.get_account_status().is_authorized)
         return None
 
-    def on_post_text_command(self, command_name: str, args: dict):
+    def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:
         if command_name != "auto_complete":
             return
 

--- a/listeners.py
+++ b/listeners.py
@@ -1,5 +1,9 @@
+import functools
+
 import sublime
 import sublime_plugin
+from LSP.plugin import Session
+from LSP.plugin.core.types import FEATURES_TIMEOUT, debounced
 from LSP.plugin.core.typing import Any, Dict, Optional, Tuple
 
 from .plugin import CopilotPlugin
@@ -8,17 +12,27 @@ from .utils import get_setting
 
 
 class ViewEventListener(sublime_plugin.ViewEventListener):
-    def on_modified_async(self) -> None:
+    def _get_session(self) -> Tuple[Optional[CopilotPlugin], Optional[Session]]:
         plugin = CopilotPlugin.plugin_from_view(self.view)
         if not plugin:
-            return
+            return None, None
 
         session = plugin.weaksession()
         if not session:
-            return
+            return plugin, None
 
-        if get_setting(session, "auto_ask_completions"):
-            self.view.run_command("copilot_ask_completions")
+        return plugin, session
+
+    def on_modified_async(self) -> None:
+        plugin, session = self._get_session()
+
+        if plugin and session and get_setting(session, "auto_ask_completions"):
+            debounced(
+                functools.partial(plugin.request_get_completions, self.view),
+                FEATURES_TIMEOUT,
+                lambda: not ViewCompletionManager(self.view).is_waiting,
+                async_thread=True,
+            )
 
     def on_deactivated_async(self) -> None:
         ViewCompletionManager(self.view).hide()
@@ -40,6 +54,15 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
         if key == "copilot.is_authorized":
             return test(CopilotPlugin.get_account_status().is_authorized)
         return None
+
+    def on_post_text_command(self, command_name: str, args: dict):
+        if command_name != "auto_complete":
+            return
+
+        _, session = self._get_session()
+
+        if session and get_setting(session, "hook_to_auto_complete_command"):
+            self.view.run_command("copilot_ask_completions")
 
 
 class EventListener(sublime_plugin.EventListener):

--- a/listeners.py
+++ b/listeners.py
@@ -17,11 +17,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
         if not plugin:
             return None, None
 
-        session = plugin.weaksession()
-        if not session:
-            return plugin, None
-
-        return plugin, session
+        return plugin, plugin.weaksession()
 
     def on_modified_async(self) -> None:
         plugin, session = self._get_session()

--- a/listeners.py
+++ b/listeners.py
@@ -59,10 +59,10 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
         if command_name != "auto_complete":
             return
 
-        _, session = self._get_session()
+        plugin, session = self._get_session()
 
-        if session and get_setting(session, "hook_to_auto_complete_command"):
-            self.view.run_command("copilot_ask_completions")
+        if plugin and session and get_setting(session, "hook_to_auto_complete_command"):
+            plugin.request_get_completions(self.view)
 
 
 class EventListener(sublime_plugin.EventListener):

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -24,6 +24,11 @@
                       "description": "Auto ask the server for completions. Otherwise, you have to trigger it manually.",
                       "type": "boolean"
                     },
+                    "hook_to_auto_complete_command": {
+                      "default": true,
+                      "description": "Ask the server for completions when the auto_complete command is called.",
+                      "type": "boolean"
+                    },
                     "debug": {
                       "default": false,
                       "description": "Enables debug mode fo the LSP-copilot.",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,7 +25,7 @@
                       "type": "boolean"
                     },
                     "hook_to_auto_complete_command": {
-                      "default": true,
+                      "default": false,
                       "markdownDescription": "Ask the server for completions when the `auto_complete` command is called.",
                       "type": "boolean"
                     },

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -26,7 +26,7 @@
                     },
                     "hook_to_auto_complete_command": {
                       "default": true,
-                      "description": "Ask the server for completions when the auto_complete command is called.",
+                      "markdownDescription": "Ask the server for completions when the `auto_complete` command is called.",
                       "type": "boolean"
                     },
                     "debug": {


### PR DESCRIPTION
When I started working on this PR my idea was to only add `hook_to_auto_complete_command` settings so the copilot completion appears after clicking `ctrl+space`.  
But then I realised that our current approach of handling the `modified` event breaks the undo functionality(it undos symbol by symbols instead of changes) so this PR also fixes that