### PR TITLE
implement completion cycling command. Rename `Ask` to `Get`

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -47,7 +47,7 @@
     //     "keys": [
     //         "UNBOUND"
     //     ],
-    //     "command": "copilot_ask_completions",
+    //     "command": "copilot_get_completions",
     //     "context": [
     //         {
     //             "key": "copilot.is_authorized",

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -11,7 +11,7 @@
 	],
 	"initializationOptions": {},
 	"settings": {
-		"auto_ask_completions": true,
+		"auto_get_completions": true,
 		"debug": false,
 		"telemetry": false
 	},

--- a/Main.sublime-commands
+++ b/Main.sublime-commands
@@ -4,6 +4,10 @@
         "command": "copilot_check_status"
     },
     {
+        "caption": "Copilot: Get Completion Cycling",
+        "command": "copilot_get_completion_cycling"
+    },
+    {
         "caption": "Copilot: Get Panel Completions",
         "command": "copilot_get_panel_completions"
     },

--- a/commands.py
+++ b/commands.py
@@ -151,7 +151,7 @@ class CopilotGetVersionCommand(CopilotTextCommand):
         message_dialog("Server version: {}", payload["version"])
 
 
-class CopilotAskCompletionsCommand(CopilotTextCommand):
+class CopilotGetCompletionsCommand(CopilotTextCommand):
     def run(self, _: sublime.Edit) -> None:
         plugin = CopilotPlugin.from_view(self.view)
         if not plugin:
@@ -159,6 +159,20 @@ class CopilotAskCompletionsCommand(CopilotTextCommand):
 
         debounced(
             functools.partial(plugin.request_get_completions, self.view),
+            FEATURES_TIMEOUT,
+            lambda: not ViewCompletionManager(self.view).is_waiting,
+            async_thread=True,
+        )
+
+
+class CopilotGetCompletionCyclingCommand(CopilotTextCommand):
+    def run(self, _: sublime.Edit) -> None:
+        plugin = CopilotPlugin.from_view(self.view)
+        if not plugin:
+            return
+
+        debounced(
+            functools.partial(plugin.request_get_completions_cycle, self.view),
             FEATURES_TIMEOUT,
             lambda: not ViewCompletionManager(self.view).is_waiting,
             async_thread=True,

--- a/listeners.py
+++ b/listeners.py
@@ -17,8 +17,9 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
         if not session:
             return
 
-        if get_setting(session, "auto_ask_completions"):
-            self.view.run_command("copilot_ask_completions")
+        # auto_ask_completions is deprecated
+        if get_setting(session, "auto_get_completions") or get_setting(session, "auto_ask_completions"):
+            self.view.run_command("copilot_get_completions")
 
     def on_deactivated_async(self) -> None:
         ViewCompletionManager(self.view).hide()

--- a/plugin.py
+++ b/plugin.py
@@ -16,6 +16,7 @@ from .constants import (
     PACKAGE_VERSION,
     REQ_CHECK_STATUS,
     REQ_GET_COMPLETIONS,
+    REQ_GET_COMPLETIONS_CYCLING,
     REQ_SET_EDITOR_INFO,
 )
 from .types import (
@@ -180,6 +181,12 @@ class CopilotPlugin(NpmClientHandler):
         pass
 
     def request_get_completions(self, view: sublime.View) -> None:
+        self._request_completions(view=view, request=REQ_GET_COMPLETIONS)
+
+    def request_get_completions_cycle(self, view: sublime.View) -> None:
+        self._request_completions(view=view, request=REQ_GET_COMPLETIONS_CYCLING)
+
+    def _request_completions(self, view: sublime.View, request: str) -> None:
         completion_manager = ViewCompletionManager(view)
         completion_manager.hide()
 
@@ -195,7 +202,7 @@ class CopilotPlugin(NpmClientHandler):
 
         completion_manager.is_waiting = True
         session.send_request_async(
-            Request(REQ_GET_COMPLETIONS, params),
+            Request(request, params),
             functools.partial(self._on_get_completions, view, region=sel[0].to_tuple()),
         )
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -21,6 +21,11 @@
                   "properties": {
                     "auto_ask_completions": {
                       "default": true,
+                      "description": "(Deprecated: Use `auto_get_completions`) Auto ask the server for completions. Otherwise, you have to trigger it manually.",
+                      "type": "boolean"
+                    },
+                    "auto_get_completions": {
+                      "default": true,
                       "description": "Auto ask the server for completions. Otherwise, you have to trigger it manually.",
                       "type": "boolean"
                     },


### PR DESCRIPTION
### What

Implement the completion cycling command.


### Breaking

- Rename `auto_ask_completions` and `CopilotAskCompletionsCommand` to fall inline with command names `Get`