### PR TITLE
fix: wrong syntax highlighting for embedded languages

### DIFF
--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -215,9 +215,11 @@ class _PopupCompletion:
 
     @property
     def popup_content(self) -> str:
+        self.completion = self.completion_manager.current_completion
+        assert self.completion  # our code flow guarantees this
         return self.COMPLETION_TEMPLATE.format(
             header_items=" &nbsp;".join(self.popup_header_items),
-            lang=get_view_language_id(self.view),
+            lang=get_view_language_id(self.view, self.completion["point"]),
             code=self.popup_code,
         )
 

--- a/plugin/ui/panel_completion.py
+++ b/plugin/ui/panel_completion.py
@@ -236,7 +236,7 @@ class _PanelCompletion:
                 self.COMPLETION_SECTION_TEMPLATE.format(
                     header_items=" &nbsp;".join(self.completion_header_items(completion, self.view.id(), index)),
                     score=completion["score"],
-                    lang=get_view_language_id(self.view),
+                    lang=get_view_language_id(self.view, completion["region"][1]),
                     code=fix_completion_syntax_highlight(
                         self.view,
                         completion["region"][1],

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -104,6 +104,13 @@ def get_view_language_id(view: sublime.View, point: int = 0) -> str:
     """Find the language ID of the deepest scope satisfying `source | text | embedding` at `point`."""
     for scope in reversed(view.scope_name(point).split(" ")):
         if sublime.score_selector(scope, "source | text | embedding"):
+            try:
+                # For some embedded languages, they are scoped as "EMBEDDED_LANG.embedded.PARENT_LANG"
+                # such as "source.php.embedded.html" and we only want those parts before "embedded".
+                scope_parts = scope.split(".")
+                scope = ".".join(scope_parts[: scope_parts.index("embedded")])
+            except ValueError:
+                pass
             return basescope2languageid(scope)
     return ""
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 import traceback
+from itertools import takewhile
 
 import mdpopups
 import sublime
@@ -104,14 +105,9 @@ def get_view_language_id(view: sublime.View, point: int = 0) -> str:
     """Find the language ID of the deepest scope satisfying `source | text | embedding` at `point`."""
     for scope in reversed(view.scope_name(point).split(" ")):
         if sublime.score_selector(scope, "source | text | embedding"):
-            try:
-                # For some embedded languages, they are scoped as "EMBEDDED_LANG.embedded.PARENT_LANG"
-                # such as "source.php.embedded.html" and we only want those parts before "embedded".
-                scope_parts = scope.split(".")
-                scope = ".".join(scope_parts[: scope_parts.index("embedded")])
-            except ValueError:
-                pass
-            return basescope2languageid(scope)
+            # For some embedded languages, they are scoped as "EMBEDDED_LANG.embedded.PARENT_LANG"
+            # such as "source.php.embedded.html" and we only want those parts before "embedded".
+            return basescope2languageid(".".join(takewhile(lambda s: s != "embedded", scope.split("."))))
     return ""
 
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -100,7 +100,13 @@ def get_setting(session: Session, key: str, default: Optional[Union[str, bool, L
     return value
 
 
-def get_view_language_id(view: sublime.View) -> str:
+def get_view_language_id(view: sublime.View, point: Optional[int] = None) -> str:
+    # if `point` is provided, find the language ID of the deepest "source", "text" or "embedding" scope at `point`
+    if point is not None:
+        for scope in reversed(view.scope_name(point).split(" ")):
+            if sublime.score_selector(scope, "source | text | embedding"):
+                return basescope2languageid(scope)
+    # find language ID of the base scope as the fallback
     syntax = view.syntax() or sublime.find_syntax_by_name("Plain Text")[0]
     return basescope2languageid(syntax.scope)
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -100,15 +100,12 @@ def get_setting(session: Session, key: str, default: Optional[Union[str, bool, L
     return value
 
 
-def get_view_language_id(view: sublime.View, point: Optional[int] = None) -> str:
-    # if `point` is provided, find the language ID of the deepest "source", "text" or "embedding" scope at `point`
-    if point is not None:
-        for scope in reversed(view.scope_name(point).split(" ")):
-            if sublime.score_selector(scope, "source | text | embedding"):
-                return basescope2languageid(scope)
-    # find language ID of the base scope as the fallback
-    syntax = view.syntax() or sublime.find_syntax_by_name("Plain Text")[0]
-    return basescope2languageid(syntax.scope)
+def get_view_language_id(view: sublime.View, point: int = 0) -> str:
+    """Find the language ID of the deepest scope satisfying `source | text | embedding` at `point`."""
+    for scope in reversed(view.scope_name(point).split(" ")):
+        if sublime.score_selector(scope, "source | text | embedding"):
+            return basescope2languageid(scope)
+    return ""
 
 
 def message_dialog(msg_: str, *args, error_: bool = False, console_: bool = False, **kwargs) -> None:


### PR DESCRIPTION
Fixes https://github.com/TheSecEng/LSP-copilot/issues/33

---

For example, syntax highlighting for completing JS codes inside Markdown fenced code block.

![image](https://user-images.githubusercontent.com/6594915/181341126-95ae24f3-4040-4559-a676-d77b0bf14c6a.png)

The main idea is to get the deepest/last `source | text | embedding` scope and find the languageId for it.

For the example above, the scope at the cursor is `text.html.markdown markup.raw.code-fence.javascript.markdown-gfm source.js`. We should take `source.js` for resolving languageId rather than `text.html.markdown`.
