### PR TITLE
refactor: better completion debounce implementation

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -167,12 +167,6 @@ class CopilotAskCompletionsCommand(CopilotTextCommand):
         plugin.request_get_completions(self.view)
 
 
-class CopilotAskCompletionsCyclingCommand(CopilotTextCommand):
-    @_provide_plugin_session()
-    def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
-        plugin.request_get_completions_cycling(self.view)
-
-
 class CopilotAcceptPanelCompletionShimCommand(CopilotWindowCommand):
     def run(self, view_id: int, completion_index: int) -> None:
         view = find_view_by_id(view_id)

--- a/plugin/constants.py
+++ b/plugin/constants.py
@@ -8,7 +8,7 @@ COPILOT_VIEW_SETTINGS_PREFIX = "copilot.completion"
 
 REQ_CHECK_STATUS = "checkStatus"  # done
 REQ_GET_COMPLETIONS = "getCompletions"  # done
-REQ_GET_COMPLETIONS_CYCLING = "getCompletionsCycling"
+REQ_GET_COMPLETIONS_CYCLING = "getCompletionsCycling"  # done
 REQ_GET_PANEL_COMPLETIONS = "getPanelCompletions"  # done
 REQ_GET_VERSION = "getVersion"  # done
 REQ_NOTIFY_ACCEPTED = "notifyAccepted"  # done

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -1,8 +1,5 @@
-import functools
-
 import sublime
 import sublime_plugin
-from LSP.plugin.core.types import FEATURES_TIMEOUT, debounced
 from LSP.plugin.core.typing import Any, Dict, Optional, Tuple
 
 from .plugin import CopilotPlugin
@@ -13,14 +10,13 @@ from .utils import get_setting
 class ViewEventListener(sublime_plugin.ViewEventListener):
     def on_modified_async(self) -> None:
         plugin, session = CopilotPlugin.plugin_session(self.view)
-
-        if plugin and session and get_setting(session, "auto_ask_completions"):
-            debounced(
-                functools.partial(plugin.request_get_completions, self.view),
-                FEATURES_TIMEOUT,
-                lambda: not ViewCompletionManager(self.view).is_waiting,
-                async_thread=True,
-            )
+        if (
+            plugin
+            and session
+            and get_setting(session, "auto_ask_completions")
+            and not ViewCompletionManager(self.view).is_waiting
+        ):
+            plugin.request_get_completions(self.view)
 
     def on_deactivated_async(self) -> None:
         ViewCompletionManager(self.view).hide()

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -32,6 +32,7 @@ from .types import (
 from .ui import ViewCompletionManager, ViewPanelCompletionManager
 from .utils import (
     all_views,
+    debounce,
     prepare_completion_request,
     preprocess_completions,
     preprocess_panel_completions,
@@ -214,15 +215,12 @@ class CopilotPlugin(NpmClientHandler):
         pass
 
     @_guard_view()
+    @debounce()
     def request_get_completions(self, view: sublime.View) -> None:
-        self._request_completions(view, REQ_GET_COMPLETIONS)
-        self.request_get_completions_cycling(view)
-
-    @_guard_view()
-    def request_get_completions_cycling(self, view: sublime.View) -> None:
+        self._request_completions(view, REQ_GET_COMPLETIONS, no_callback=True)
         self._request_completions(view, REQ_GET_COMPLETIONS_CYCLING)
 
-    def _request_completions(self, view: sublime.View, request: str) -> None:
+    def _request_completions(self, view: sublime.View, request: str, *, no_callback: bool = False) -> None:
         completion_manager = ViewCompletionManager(view)
         completion_manager.hide()
 
@@ -236,11 +234,13 @@ class CopilotPlugin(NpmClientHandler):
         if not params:
             return
 
-        completion_manager.is_waiting = True
-        session.send_request_async(
-            Request(request, params),
-            functools.partial(self._on_get_completions, view, region=sel[0].to_tuple()),
-        )
+        if no_callback:
+            callback = lambda _: None
+        else:
+            completion_manager.is_waiting = True
+            callback = functools.partial(self._on_get_completions, view, region=sel[0].to_tuple())
+
+        session.send_request_async(Request(request, params), callback)
 
     def _on_get_completions(
         self,

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -65,16 +65,18 @@ def debounce(time_s: float = 0.3) -> Callable[[T_Callable], T_Callable]:
         @wraps(func)
         def debounced(*args: Any, **kwargs: Any) -> None:
             def call_function() -> Any:
-                debounced._timer = None
+                delattr(debounced, "_timer")
                 return func(*args, **kwargs)
 
-            if debounced._timer is not None:
-                debounced._timer.cancel()
+            timer = getattr(debounced, "_timer", None)  # type: Optional[threading.Timer]
+            if timer is not None:
+                timer.cancel()
 
-            debounced._timer = threading.Timer(time_s, call_function)
-            debounced._timer.start()
+            timer = threading.Timer(time_s, call_function)
+            timer.start()
+            setattr(debounced, "_timer", timer)
 
-        debounced._timer = None
+        setattr(debounced, "_timer", None)
         return cast(T_Callable, debounced)
 
     return decorator

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,6 +1,8 @@
 import os
 import textwrap
+import threading
 import traceback
+from functools import wraps
 from itertools import takewhile
 from operator import itemgetter
 
@@ -8,11 +10,11 @@ import mdpopups
 import sublime
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import basescope2languageid
-from LSP.plugin.core.typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, TypeVar, Union
+from LSP.plugin.core.typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, TypeVar, Union, cast
 from LSP.plugin.core.url import filename_to_uri
 
 from .constants import COPILOT_VIEW_SETTINGS_PREFIX, PACKAGE_NAME
-from .types import CopilotPayloadCompletion, CopilotPayloadPanelSolution
+from .types import CopilotPayloadCompletion, CopilotPayloadPanelSolution, T_Callable
 
 T = TypeVar("T")
 T_Number = TypeVar("T_Number", bound=Union[int, float])
@@ -49,6 +51,33 @@ def clamp(val: T_Number, min_val: Optional[T_Number] = None, max_val: Optional[T
     if max_val is not None and val > max_val:  # type: ignore
         return max_val
     return val
+
+
+def debounce(time_s: float = 0.3) -> Callable[[T_Callable], T_Callable]:
+    """
+    Debounce a function so that it's called after `time_s` seconds.
+    If it's called multiple times in the time frame, it will only run the last call.
+
+    Taken and modified from https://github.com/salesforce/decorator-operations
+    """
+
+    def decorator(func: T_Callable) -> T_Callable:
+        @wraps(func)
+        def debounced(*args: Any, **kwargs: Any) -> None:
+            def call_function() -> Any:
+                debounced._timer = None
+                return func(*args, **kwargs)
+
+            if debounced._timer is not None:
+                debounced._timer.cancel()
+
+            debounced._timer = threading.Timer(time_s, call_function)
+            debounced._timer.start()
+
+        debounced._timer = None
+        return cast(T_Callable, debounced)
+
+    return decorator
 
 
 def find_sheet_by_id(id: int) -> Optional[sublime.Sheet]:


### PR DESCRIPTION
This PR does following things.

- Real debounce implementation.  I.e., only the last call will be executed during a time frame.
- Do not show popup for `REQ_GET_COMPLETIONS` results but only show popup for `REQ_GET_COMPLETIONS_CYCLING` results.
- Remove `CopilotAskCompletionsCyclingCommand` since it makes no sense to use it alone.