### PR TITLE
fix: scroll view to make full completed text visible

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -192,6 +192,7 @@ class CopilotAcceptPanelCompletionCommand(CopilotTextCommand):
         # it seems that `completionText` always assume your cursor is at the end of the line
         source_line_region = self.view.line(sublime.Region(*completion["region"]))
         self.view.insert(edit, source_line_region.end(), completion["completionText"])
+        self.view.show(self.view.sel(), show_surrounds=False, animate=self.view.settings().get("animation_enabled"))
 
         completion_manager.close()
 
@@ -223,6 +224,7 @@ class CopilotAcceptCompletionCommand(CopilotTextCommand):
         source_line_region = self.view.line(completion["point"])
         self.view.erase(edit, source_line_region)
         self.view.insert(edit, source_line_region.begin(), completion["text"])
+        self.view.show(self.view.sel(), show_surrounds=False, animate=self.view.settings().get("animation_enabled"))
 
         # notify the current completion as accepted
         self._record_telemetry(session, REQ_NOTIFY_ACCEPTED, {"uuid": completion["uuid"]})

--- a/plugin/ui/panel_completion.py
+++ b/plugin/ui/panel_completion.py
@@ -302,6 +302,8 @@ class _PanelCompletion:
             window.set_layout(self.completion_manager.original_layout)
             self.completion_manager.original_layout = None
 
+        window.focus_view(self.view)
+
     @staticmethod
     def _prepare_popup_code_display_text(display_text: str) -> str:
         # The returned completion is in the form of


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6594915/182035292-b65efff0-d577-45c2-86a1-4c434dbf4af4.png)

Say your cursor is near the bottom of the viewport. After accepting a multiline completion, the completed text can be out of the viewport. This PR mimics what will happen as-if you paste those completion codes at the cursor position. ST will scroll the viewport.

- `animation_enabled` is a default ST settings. (Controls animation throughout the application)
