### PR TITLE
refactor: remove default when getting existing settings

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -33,7 +33,7 @@ from .types import (
 from .ui import ViewCompletionManager, ViewPanelCompletionManager
 from .utils import (
     find_view_by_id,
-    get_setting,
+    get_session_setting,
     message_dialog,
     ok_cancel_dialog,
     prepare_completion_request,
@@ -112,7 +112,7 @@ class CopilotCommandBase(metaclass=ABCMeta):
     requirement = REQUIRE_SIGN_IN | REQUIRE_AUTHORIZED
 
     def _can_meet_requirement(self, session: Session) -> bool:
-        if get_setting(session, "debug", False):
+        if get_session_setting(session, "debug"):
             return True
 
         has_signed_in, is_authorized = CopilotPlugin.get_account_status()
@@ -133,7 +133,7 @@ class CopilotTextCommand(CopilotCommandBase, LspTextCommand, metaclass=ABCMeta):
         request: str,
         payload: Union[CopilotPayloadNotifyAccepted, CopilotPayloadNotifyRejected],
     ) -> None:
-        if not get_setting(session, "telemetry", False):
+        if not get_session_setting(session, "telemetry"):
             return
 
         session.send_request(Request(request, payload), lambda _: None)
@@ -284,7 +284,7 @@ class CopilotCheckStatusCommand(CopilotTextCommand):
 
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
-        local_checks = get_setting(session, "local_checks", False)
+        local_checks = get_session_setting(session, "local_checks")
         session.send_request(Request(REQ_CHECK_STATUS, {"localChecksOnly": local_checks}), self._on_result_check_status)
 
     def _on_result_check_status(self, payload: Union[CopilotPayloadSignInConfirm, CopilotPayloadSignOut]) -> None:

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -7,14 +7,14 @@ from LSP.plugin.core.typing import Any, Dict, Optional, Tuple
 
 from .plugin import CopilotPlugin
 from .ui import ViewCompletionManager, ViewPanelCompletionManager
-from .utils import get_setting
+from .utils import get_session_setting
 
 
 class ViewEventListener(sublime_plugin.ViewEventListener):
     def on_modified_async(self) -> None:
         plugin, session = CopilotPlugin.plugin_session(self.view)
 
-        if plugin and session and get_setting(session, "auto_ask_completions"):
+        if plugin and session and get_session_setting(session, "auto_ask_completions"):
             debounced(
                 functools.partial(plugin.request_get_completions, self.view),
                 FEATURES_TIMEOUT,
@@ -49,7 +49,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
 
         plugin, session = CopilotPlugin.plugin_session(self.view)
 
-        if plugin and session and get_setting(session, "hook_to_auto_complete_command"):
+        if plugin and session and get_session_setting(session, "hook_to_auto_complete_command"):
             plugin.request_get_completions(self.view)
 
 

--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -123,7 +123,7 @@ class ViewCompletionManager:
             return 0
 
         # clamp if it's out-of-bounds or treat it as cyclic?
-        if self.view.settings().get("auto_complete_cycle", False):
+        if self.view.settings().get("auto_complete_cycle"):
             return index % completions_cnt
         return clamp(index, 0, completions_cnt - 1)
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -96,12 +96,10 @@ def get_project_relative_path(path: str) -> str:
     return relpath
 
 
-def get_setting(session: Session, key: str, default: Optional[Union[str, bool, List[str]]] = None) -> Any:
+def get_session_setting(session: Session, key: str, default: Any = None) -> Any:
     """Get the value of the `key` in "settings" in this plugin's "LSP-*.sublime-settings"."""
     value = session.config.settings.get(key)
-    if value is None:
-        return default
-    return value
+    return default if value is None else value
 
 
 def get_view_language_id(view: sublime.View, point: int = 0) -> str:
@@ -154,9 +152,9 @@ def prepare_completion_request(view: sublime.View) -> Optional[Dict[str, Any]]:
     return {
         "doc": {
             "source": view.substr(sublime.Region(0, view.size())),
-            "tabSize": view.settings().get("tab_size", 4),
+            "tabSize": view.settings().get("tab_size"),
             "indentSize": 1,  # there is no such concept in ST
-            "insertSpaces": view.settings().get("translate_tabs_to_spaces", False),
+            "insertSpaces": view.settings().get("translate_tabs_to_spaces"),
             "path": file_path,
             "uri": file_path and filename_to_uri(file_path),
             "relativePath": get_project_relative_path(file_path),


### PR DESCRIPTION
Since those settings must exist, there is no need to add default values.
If they break, that means there are issues like typo in our codes.

Also renames `get_settings` to `get_session_settings`.