### PR TITLE
fix: do not get completions during the lsp_save command

### DIFF
--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -200,6 +200,10 @@ class _BaseCompletion(metaclass=ABCMeta):
     def hide(cls, view: sublime.View) -> None:
         pass
 
+    @classmethod
+    def close(cls, view: sublime.View) -> None:
+        pass
+
 
 class _PopupCompletion(_BaseCompletion):
     name = "popup"


### PR DESCRIPTION
Some LSP servers are slower than others, and, for example, formatting on save (that is caused by the `lsp_save` command) can take a bit longer.  
Because of that, the `on_modified_async` callback gets triggered in the middle of the call and a completion gets displayed(because it may have formatted the source code).

This PR blocks the completion request during the `lsp_save` command duration