### PR TITLE
fix: align accept completion logic with VSCode

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -6,7 +6,7 @@
         "command": "copilot_accept_completion",
         "context": [
             {
-                "key": "setting.copilot.completion.is_visible"
+                "key": "copilot.is_on_completion"
             }
         ]
     },

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -66,10 +66,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
         if key == "copilot.is_on_completion":
             vcm = ViewCompletionManager(self.view)
 
-            if not vcm.is_visible:
-                return test(False)
-
-            if len(self.view.sel()) < 1:
+            if not vcm.is_visible or len(self.view.sel()) < 1 or not vcm.current_completion:
                 return test(False)
 
             point = self.view.sel()[0].begin()

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -73,9 +73,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             line = self.view.line(point)
             beginning_of_line = self.view.substr(sublime.Region(line.begin(), point))
 
-            return test(
-                beginning_of_line.strip() or re.match(r"(?!\s)", str(vcm.current_completion["displayText"]))
-            )
+            return test(beginning_of_line.strip() or not re.match(r"\s", vcm.current_completion["displayText"]))
 
         return None
 

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -77,7 +77,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             beginning_of_line = self.view.substr(sublime.Region(line.begin(), point))
 
             return test(
-                beginning_of_line.strip() != "" or not re.match(r"\s+", str(vcm.current_completion["displayText"]))
+                beginning_of_line.strip() or re.match(r"(?!\s)", str(vcm.current_completion["displayText"]))
             )
 
         return None

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -1,3 +1,5 @@
+import re
+
 import sublime
 import sublime_plugin
 from LSP.plugin.core.typing import Any, Dict, Optional, Tuple
@@ -57,8 +59,25 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
 
         if key == "copilot.has_signed_in":
             return test(CopilotPlugin.get_account_status().has_signed_in)
+
         if key == "copilot.is_authorized":
             return test(CopilotPlugin.get_account_status().is_authorized)
+
+        if key == "copilot.is_on_completion":
+            vcm = ViewCompletionManager(self.view)
+
+            if not vcm.is_visible:
+                return test(False)
+
+            if len(self.view.sel()) < 1:
+                return test(False)
+
+            point = self.view.sel()[0].begin()
+            line = self.view.line(point)
+            beginning_of_line = self.view.substr(sublime.Region(line.begin(), point))
+
+            return test(beginning_of_line.strip() != "" or not re.match(r"\s+", vcm.current_completion["displayText"]))
+
         return None
 
     def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -76,7 +76,9 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             line = self.view.line(point)
             beginning_of_line = self.view.substr(sublime.Region(line.begin(), point))
 
-            return test(beginning_of_line.strip() != "" or not re.match(r"\s+", vcm.current_completion["displayText"]))
+            return test(
+                beginning_of_line.strip() != "" or not re.match(r"\s+", str(vcm.current_completion["displayText"]))
+            )
 
         return None
 


### PR DESCRIPTION
In VSCode when the cursor is at the beginning of the line and there is a visible completion, the completion gets accepted only when the cursor is literally near the completion.  
So, for example, when the cursor is at the beginning of the line and the completion is a few tabs/stop away then accepting a completion(e.g. pressing the tab) won't accept the completion and instead trigger the tab key.

https://user-images.githubusercontent.com/471335/193867633-2130301a-4591-466a-8e80-8e350f3321e4.mov

This PR emulates this logic by adding a query context that is used by default.  
It is important to either keep this logic default or remove the default keymap for the tab at all because otherwise there will be no way to override the tab key in the user keymaps.

https://user-images.githubusercontent.com/471335/193867564-73603493-8ee6-48e4-9d47-64ea10c64714.mov

Also, this change should play nicely with this one https://github.com/TheSecEng/LSP-copilot/issues/52  
So once https://github.com/TheSecEng/LSP-copilot/issues/52 is implemented the completion will be updated right away without an extra request/delay(similar to VSCode)