### PR TITLE
fix: fix copilot.is_on_completion event context

### DIFF
--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -73,7 +73,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             line = self.view.line(point)
             beginning_of_line = self.view.substr(sublime.Region(line.begin(), point))
 
-            return test(beginning_of_line.strip() or not re.match(r"\s", vcm.current_completion["displayText"]))
+            return test(beginning_of_line.strip() != "" or not re.match(r"\s", vcm.current_completion["displayText"]))
 
         return None
 


### PR DESCRIPTION
`!=` part is required to ensure the value is boolean