### PR TITLE
feat: update the phantom while typing

### DIFF
--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -34,7 +34,8 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             return
 
         vcm = ViewCompletionManager(self.view)
-        vcm.handle_text_change()
+        if vcm.handle_text_change():
+            return
 
         if not self._is_saving and get_session_setting(session, "auto_ask_completions") and not vcm.is_waiting:
             plugin.request_get_completions(self.view)

--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -115,11 +115,31 @@ class ViewCompletionManager:
 
         self.hide()
 
-    def handle_text_change(self) -> None:
+    def handle_text_change(self) -> bool:
         if not (self.is_phantom and self.is_visible):
-            return
+            return False
 
-        self.hide()
+        if self.current_completion and len(self.view.sel()) == 1 and self.view.sel()[0].empty():
+            current_completion = self.current_completion
+            point = self.view.sel()[0].begin()
+            region = sublime.Region(current_completion["point"], point)
+            text = self.view.substr(region)
+
+            if current_completion["displayText"].startswith(text):
+                current_completion["displayText"] = current_completion["displayText"][len(region) :]
+                self.completion_style_type(
+                    self.view, current_completion, self.completion_index, len(self.completions)
+                ).show()
+
+                return True
+            else:
+                self.hide()
+
+                return False
+        else:
+            self.hide()
+
+            return False
 
     def handle_close(self) -> None:
         if not self.is_phantom:


### PR DESCRIPTION
Closes #52

This PR tries to emulate VSCode when the phantom(ghost) text is updated while typing(without triggering an extra request).  
Unfortunately, due to the phantom API limitations, it is currently not possible(see the attached video)

https://user-images.githubusercontent.com/471335/194121909-c98ed8eb-4ae7-4221-ac32-b7bd7a1b7cfa.mov

The main problem is that the cursor always jumps when updating the phantom in real time.

