### PR TITLE
refactor: use lsp_check_applicable command

### DIFF
--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -62,7 +62,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
             plugin.request_get_completions(self.view)
 
     def on_activated_async(self) -> None:
-        self.view.run_command('lsp_check_applicable', {'session_name': PACKAGE_NAME})
+        self.view.run_command("lsp_check_applicable", {"session_name": PACKAGE_NAME})
         _, session = CopilotPlugin.plugin_session(self.view)
         if session and CopilotPlugin.is_applicable(self.view, session.config):
             if (window := self.view.window()) and self.view.name() != "Copilot Chat":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "LSP-copilot"
+name = "lsp-copilot"
 version = "0.0.0"
 description = "GitHub Copilot support for Sublime Text LSP plugin provided through Copilot.vim."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "Jinja2==3.*",
+  "jinja2==3.*",
   "more-itertools>=10,<11",
   "requests>=2,<3",
   "typing-extensions>=4.12",


### PR DESCRIPTION
LSP had a `lsp_check_applicable` command for a while to handle copilot use case.

Minor type fixes in the process.