### PR TITLE
chore: fix workflow version

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ['3.8']
 
     steps:
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
       - uses: actions/checkout@v6
         with:
           submodules: recursive


### PR DESCRIPTION
that workflow doesn't publish major-only tags anymore