### PR TITLE
fix(helpers): guard avatar fetch against network errors

### DIFF
--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -103,7 +103,14 @@ class GithubInfo:
             cls.clear_avatar()
             return
 
-        if (req := requests.get(f"https://github.com/{username}.png?size={size}")).ok:
+        try:
+            req = requests.get(f"https://github.com/{username}.png?size={size}")
+        except requests.exceptions.RequestException as e:
+            log_error(f'Failed to fetch avatar for "{username}": {e}.')
+            cls.clear_avatar()
+            return
+
+        if req.ok:
             data = req.content
         # see https://github.com/TerminalFi/LSP-copilot/issues/218#issuecomment-2535522265
         elif req.status_code == 404:


### PR DESCRIPTION
Wrap requests.get in try/except to handle proxy/SSL failures gracefully instead of crashing the plugin.

Fixes https://github.com/sublimelsp/LSP-copilot/issues/284