### PR TITLE
refactor: initialize version manager before plugin registration

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -115,13 +115,13 @@ __all__ = (
 
 def plugin_loaded() -> None:
     """Executed when this plugin is loaded."""
+    version_manager.plugin_storage_dir = CopilotPlugin.plugin_storage_path
+    version_manager.server_version = SERVER_VERSION
+
     CopilotPlugin.register()
     copilot_ignore_observer.setup()
     for window in all_windows():
         CopilotIgnore(window).load_patterns()
-
-    version_manager.plugin_storage_dir = CopilotPlugin.plugin_storage_path
-    version_manager.server_version = SERVER_VERSION
 
 
 def plugin_unloaded() -> None:


### PR DESCRIPTION
## Summary
- Initialize the Copilot language server version manager before registering the LSP plugin.
- Keep the existing storage path and server version sources unchanged.

## Rationale
`CopilotPlugin.register()` can make the plugin available for LSP session startup. `on_pre_start_async()` checks `version_manager.is_installed`, which depends on `plugin_storage_dir` and `server_version` already being initialized. Setting those fields before registration avoids an `AttributeError` if startup is triggered before the remaining `plugin_loaded()` setup has completed.

## Validation
- Syntax-checked `plugin/__init__.py` with Python `compile(...)`.