### PR TITLE
chore(types): fix wrong type

### DIFF
--- a/plugin/ui/chat.py
+++ b/plugin/ui/chat.py
@@ -196,7 +196,7 @@ class BaseConversationEntry(ABC):
         self.manager.is_visible = False
         self.manager.window.run_command("hide_panel")
         if self.manager.original_layout:
-            self.window.set_layout(self.manager.original_layout)
+            self.window.set_layout(self.manager.original_layout)  # pyright: ignore[reportArgumentType]
             self.manager.original_layout = None
 
         if view := self.window.active_view():
@@ -219,7 +219,7 @@ class BaseConversationEntry(ABC):
 
     def _open_in_side_by_side(self, window: sublime.Window) -> None:
         """Open the conversation sheet in side-by-side layout."""
-        self.manager.original_layout = window.layout()
+        self.manager.original_layout = window.layout()  # pyright: ignore[reportAttributeAccessIssue]
         window.set_layout({
             "cols": [0.0, 0.5, 1.0],
             "rows": [0.0, 1.0],

--- a/plugin/ui/chat.py
+++ b/plugin/ui/chat.py
@@ -181,6 +181,8 @@ class BaseConversationEntry(ABC):
         """Update the conversation sheet content."""
         if not (sheet := self.window.transient_sheet_in_group(self.manager.group_id)):
             return
+        if not isinstance(sheet, sublime.HtmlSheet):
+            return
 
         mdpopups.update_html_sheet(sheet=sheet, contents=self.completion_content, md=True, wrapper_class="wrapper")
 

--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -239,7 +239,6 @@ class _PopupCompletion(_BaseCompletion):
             view=self.view,
             content=self.popup_content,
             md=True,
-            layout=sublime.LAYOUT_INLINE,
             flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
             max_width=640,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
 ]
 stubPath = 'typings'
 pythonVersion = '3.8'
+typeCheckingMode = 'standard'
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
Those type errors don't show up normally because this package doesn't use good stubs for mdpopups but it does show up when using LSP stubs.

```
/usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-copilot/plugin/ui/chat.py
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-copilot/plugin/ui/chat.py:185:42 - error: Argument of type "Sheet" cannot be assigned to parameter "sheet" of type "HtmlSheet" in function "update_html_sheet"
    "Sheet" is not assignable to "HtmlSheet" (reportArgumentType)
/usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-copilot/plugin/ui/completion.py
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-copilot/plugin/ui/completion.py:242:13 - warning: No parameter named "layout" (reportCallIssue)
```