### PR TITLE
fix(models): skip non-policy-gated models in model picker

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -1025,6 +1025,10 @@ class CopilotModelsCommand(CopilotTextCommand):
 
     def _on_result_copilot_models(self, payload: list[CopilotModel]) -> None:
         window = self.view.window() or sublime.active_window()
+        models = [item for item in payload if "modelPolicy" in item]
+        if not models:
+            status_message("No policy-configurable models available", icon="❌")
+            return
         window.show_quick_panel(
             [
                 sublime.QuickPanelItem(
@@ -1032,9 +1036,9 @@ class CopilotModelsCommand(CopilotTextCommand):
                     details=item["modelName"],
                     annotation=", ".join(item["scopes"]),
                 )
-                for item in payload
+                for item in models
             ],
-            lambda index: self._set_model_policy(index, payload),
+            lambda index: self._set_model_policy(index, models),
         )
 
     def _set_model_policy(self, index: int, models: list[CopilotModel]) -> None:

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Literal, Tuple, TypeVar, TypedDict
 
 from LSP.plugin.core.protocol import Position as LspPosition, Range as LspRange
 from LSP.plugin.core.typing import StrEnum
+from typing_extensions import NotRequired
 
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
 
@@ -309,12 +310,20 @@ class CopilotUserDefinedPromptTemplates(TypedDict, total=True):
     scopes: list[str]
 
 
+class CopilotModelPolicy(TypedDict, total=True):
+    state: str
+    terms: str
+
+
 class CopilotModel(TypedDict, total=True):
     id: str
     modelFamily: str
     modelName: str
     scopes: list[str]
     isChatDefault: bool
+    modelPolicy: NotRequired[CopilotModelPolicy]
+    """Absent for models that aren't policy-gated (e.g. "auto" or completion-only models);
+    `copilot/setModelPolicy` fails for those."""
 
 
 # --------------------------- #


### PR DESCRIPTION
copilot/setModelPolicy always fails for models without a modelPolicy field in copilot/models (e.g. auto, completion-only models), so selecting them from the quick panel errored with "Failed to accept model policy". Filter them out before showing the picker.